### PR TITLE
[PYTHON] Implement `__dir__()` in `pyspark.sql.dataframe.DataFrame` to include columns

### DIFF
--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3013,12 +3013,21 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         Examples
         --------
         >>> from pyspark.sql.functions import lit
+
+        Create a dataframe with a column named 'id'.
+
         >>> df = spark.range(3)
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Includes column id
         ['id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming']
+
+        Add a column named 'i_like_pancakes'.
+
         >>> df = df.withColumn('i_like_pancakes', lit(1))
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Includes columns i_like_pancakes, id
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
+
+        Try to add an existed column 'inputFiles'.
+
         >>> df = df.withColumn('inputFiles', lit(2))
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Doesn't duplicate inputFiles
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3032,7 +3032,7 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Doesn't duplicate inputFiles
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
         """
-        attrs = super().__dir__()
+        attrs = list(super().__dir__())
         attrs.extend(attr for attr in self.columns if attr not in attrs)
         return attrs
 

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3009,8 +3009,22 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         return Column(jc)
 
     def __dir__(self):
+        """
+        Examples
+        --------
+        >>> from pyspark.sql.functions import lit
+        >>> df = spark.range(3)
+        >>> [attr for attr in dir(df) if attr[0] == 'i']
+        ['id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        >>> df = df.withColumn('i_like_pancakes', lit(1))
+        >>> [attr for attr in dir(df) if attr[0] == 'i']
+        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        >>> df = df.withColumn('inputFiles', lit(2))
+        >>> [attr for attr in dir(df) if attr[0] == 'i']
+        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        """
         attrs = super().__dir__()
-        attrs.extend(self.columns)
+        attrs.extend(attr for attr in self.columns if attr not in attrs)
         return attrs
 
     @overload

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3033,13 +3033,13 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
 
         Try to add a column named 'id2'.
-        
+
         >>> df = df.withColumn('id2', lit(3))
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # result includes id2 and sorted
         ['i_like_pancakes', 'id', 'id2', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty']
         """
-        attrs = list(super().__dir__())
-        attrs.extend(attr for attr in self.columns if attr not in attrs)
+        attrs = set(super().__dir__())
+        attrs.update(self.columns)
         return sorted(attrs)
 
     @overload

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3014,14 +3014,14 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         --------
         >>> from pyspark.sql.functions import lit
         >>> df = spark.range(3)
-        >>> [attr for attr in dir(df) if attr[0] == 'i']
-        ['id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        ['id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming']
         >>> df = df.withColumn('i_like_pancakes', lit(1))
-        >>> [attr for attr in dir(df) if attr[0] == 'i']
-        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
         >>> df = df.withColumn('inputFiles', lit(2))
-        >>> [attr for attr in dir(df) if attr[0] == 'i']
-        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming', 'is_cached']
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
         """
         attrs = super().__dir__()
         attrs.extend(attr for attr in self.columns if attr not in attrs)

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3008,19 +3008,19 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.apply(name)
         return Column(jc)
 
-    def __dir__(self):
+    def __dir__(self) -> List[str]:
         """
         Examples
         --------
         >>> from pyspark.sql.functions import lit
         >>> df = spark.range(3)
-        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Includes column id
         ['id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal', 'isStreaming']
         >>> df = df.withColumn('i_like_pancakes', lit(1))
-        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Includes columns i_like_pancakes, id
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
         >>> df = df.withColumn('inputFiles', lit(2))
-        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7]
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Doesn't duplicate inputFiles
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
         """
         attrs = super().__dir__()

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3031,10 +3031,16 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         >>> df = df.withColumn('inputFiles', lit(2))
         >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # Doesn't duplicate inputFiles
         ['i_like_pancakes', 'id', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty', 'isLocal']
+
+        Try to add a column named 'id2'.
+        
+        >>> df = df.withColumn('id2', lit(3))
+        >>> [attr for attr in dir(df) if attr[0] == 'i'][:7] # result includes id2 and sorted
+        ['i_like_pancakes', 'id', 'id2', 'inputFiles', 'intersect', 'intersectAll', 'isEmpty']
         """
         attrs = list(super().__dir__())
         attrs.extend(attr for attr in self.columns if attr not in attrs)
-        return attrs
+        return sorted(attrs)
 
     @overload
     def select(self, *cols: "ColumnOrName") -> "DataFrame":

--- a/python/pyspark/sql/dataframe.py
+++ b/python/pyspark/sql/dataframe.py
@@ -3008,6 +3008,11 @@ class DataFrame(PandasMapOpsMixin, PandasConversionMixin):
         jc = self._jdf.apply(name)
         return Column(jc)
 
+    def __dir__(self):
+        attrs = super().__dir__()
+        attrs.extend(self.columns)
+        return attrs
+
     @overload
     def select(self, *cols: "ColumnOrName") -> "DataFrame":
         ...


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://spark.apache.org/contributing.html
  2. Ensure you have added or run the appropriate tests for your PR: https://spark.apache.org/developer-tools.html
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][SPARK-XXXX] Your PR title ...'.
  4. Be sure to keep the PR description updated to reflect all changes.
  5. Please write your PR title to summarize what this PR proposes.
  6. If possible, provide a concise example to reproduce the issue for a faster review.
  7. If you want to add a new configuration, please read the guideline first for naming configurations in
     'core/src/main/scala/org/apache/spark/internal/config/ConfigEntry.scala'.
  8. If you want to add or modify an error type or message, please read the guideline first in
     'core/src/main/resources/error/README.md'.
-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Override the parent `__dir__()` method on Python `DataFrame` class to include column names. Main benefit of this is that any autocomplete engine that uses `dir()` to generate autocomplete suggestions (e.g. IPython kernel, Databricks Notebooks) will suggest column names on the completion `df.|`.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To keep `__dir__()` consistent with `__getattr__()`. So this is arguably a bug fix. Increases productivity for anyone who uses an autocomplete engine on pyspark code.

Example of column attribute completion coming for free after this change:

https://user-images.githubusercontent.com/84545946/233747057-56b2589d-d075-4d13-8349-ac5142c38c62.mov


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Will change the output of `dir(df)`. If the user chooses to use the private method `df.__dir__()`, they will also notice an output and docstring difference there.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
If benchmark tests were added, please run the benchmarks in GitHub Actions for the consistent environment, and the instructions could accord to: https://spark.apache.org/developer-tools.html#github-workflow-benchmarks.
-->
New doctest with three assertions. Output where I only ran this test:
![pyspark test passed](https://user-images.githubusercontent.com/84545946/233744674-b59191a7-08bf-4f3e-a491-945e687727b0.png)

To test it in a notebook:
```python
from pyspark.sql.dataframe import DataFrame

class DataFrameWithColAttrs(DataFrame):
    def __init__(self, df):
        super().__init__(df._jdf, df._sql_ctx if df._sql_ctx else df._session)

    def __dir__(self):
        attrs = super().__dir__()
        attrs.extend(attr for attr in self.columns if attr not in attrs)
        return attrs
```